### PR TITLE
fix warnings while creating documentation

### DIFF
--- a/ipmi/defaults/main.yml
+++ b/ipmi/defaults/main.yml
@@ -25,6 +25,7 @@ ipmi_network: {}
 #     address: 192.0.2.2
 #     netmask: 255.0.0.0
 #     gateway: 192.0.2.1
+#
 
 # IPMI SNMPv2 community
 ipmi_snmp_community: ''

--- a/mariadb/defaults/main.yml
+++ b/mariadb/defaults/main.yml
@@ -46,18 +46,21 @@ mariadb_users: []
 #     - name: web
 #       password: secure
 #       priv: 'mydb.*:INSERT,UPDATE/anotherdb.*:SELECT/yetanotherdb.*:ALL'
+#
 
 # Mariadb server id.
 #
 # .. code-block:: YAML
 #
 #   mariadb_server_id: 1
+#
 
 # Mariadb binary logs.
 #
 # .. code-block:: YAML
 #
 #   mariadb_log_bin: /var/log/mysql/mysql-bin.log
+#
 
 # Mariadb replicate-wild-do-table.
 # Replicate only some tables (wildcard allowed).
@@ -65,3 +68,4 @@ mariadb_users: []
 # .. code-block:: YAML
 #
 #   mariadb_replicate_wild_do_table: ykksm.%
+#


### PR DESCRIPTION
Fix `WARNING: Explicit markup ends without a blank line; unexpected unindent.`