### PR TITLE
telegraf: add debian stretch support

### DIFF
--- a/telegraf/meta/main.yml
+++ b/telegraf/meta/main.yml
@@ -14,6 +14,7 @@ galaxy_info:
       versions:
         - wheezy
         - jessie
+        - stretch
     - name: Ubuntu
       versions:
         - trusty


### PR DESCRIPTION
Add debian 9/stretch support to role telegraf.