### PR TITLE
network: provide system from leaking uptime over tcp timestamps

### DIFF
--- a/network/tasks/configuration.yml
+++ b/network/tasks/configuration.yml
@@ -17,6 +17,23 @@
   notify:
     - 'network reload sysctl'
 
+- name: do not leak system uptime over tcp timestamps
+  template:
+    src: etc/sysctl.d/tcp_timestamps.conf.j2
+    dest: '{{ network_config_sysctl_tcp_timestamps }}'
+    owner: root
+    group: root
+    mode: 0644
+    seuser: system_u
+    serole: object_r
+    setype: etc_t
+    selevel: s0
+  tags:
+    - 'role::network'
+    - 'role::network:config'
+  notify:
+    - 'network reload sysctl'
+
 - name: create global network configuration
   template:
     src: 'etc/{{ ansible_os_family }}/network.j2'

--- a/network/templates/etc/sysctl.d/tcp_timestamps.conf.j2
+++ b/network/templates/etc/sysctl.d/tcp_timestamps.conf.j2
@@ -1,0 +1,4 @@
+# {{ ansible_managed }}
+# Prevent system from leaking the uptime over TCP timestamps.
+
+net.ipv4.tcp_timestamps=0

--- a/network/vars/Debian.yml
+++ b/network/vars/Debian.yml
@@ -17,6 +17,9 @@ network_packages_remove:
 # system control configuration file for IPv6 RA
 network_config_sysctl_ipv6_ra: /etc/sysctl.d/network_ipv6_ra.conf
 
+# system control configuration file for tcp timestamps
+network_config_sysctl_tcp_timestamps: /etc/sysctl.d/tcp_timestamps.conf
+
 # network main configuration
 network_cfg_main: /etc/network/interfaces
 

--- a/network/vars/Debian_7.yml
+++ b/network/vars/Debian_7.yml
@@ -13,6 +13,9 @@ network_packages_remove: []
 # system control configuration file for IPv6 RA
 network_config_sysctl_ipv6_ra: /etc/sysctl.d/network_ipv6_ra.conf
 
+# system control configuration file for tcp timestamps
+network_config_sysctl_tcp_timestamps: /etc/sysctl.d/tcp_timestamps.conf
+
 # network main configuration
 network_cfg_main: /etc/network/interfaces
 

--- a/network/vars/RedHat.yml
+++ b/network/vars/RedHat.yml
@@ -16,6 +16,9 @@ network_packages_remove:
 # system control configuration file for IPv6 RA
 network_config_sysctl_ipv6_ra: /etc/sysctl.d/network_ipv6_ra.conf
 
+# system control configuration file for tcp timestamps
+network_config_sysctl_tcp_timestamps: /etc/sysctl.d/tcp_timestamps.conf
+
 # network main configuration
 network_cfg_main: /etc/sysconfig/network
 


### PR DESCRIPTION
It is possible to get the system uptime over tcp timestamps. This PR will disable TCP timestamp information leaking.