### PR TITLE
role pkg_mirror: add package python-apt

### DIFF
--- a/pkg_mirror/vars/Debian.yml
+++ b/pkg_mirror/vars/Debian.yml
@@ -3,6 +3,7 @@
 # pkg-mirror packages
 pkg_mirror_packages:
   - apt-transport-https
+  - python-apt
   - ca-certificates
 
 # pkg-mirror

--- a/pkg_mirror/vars/Ubuntu_14.yml
+++ b/pkg_mirror/vars/Ubuntu_14.yml
@@ -3,6 +3,7 @@
 # pkg-mirror packages
 pkg_mirror_packages:
   - apt-transport-https
+  - python-apt
   - ca-certificates
 
 # pkg-mirror

--- a/pkg_mirror/vars/Ubuntu_16.yml
+++ b/pkg_mirror/vars/Ubuntu_16.yml
@@ -3,6 +3,7 @@
 # pkg-mirror packages
 pkg_mirror_packages:
   - apt-transport-https
+  - python-apt
   - ca-certificates
 
 # pkg-mirror


### PR DESCRIPTION
Install package python-apt, which is needed for some ansible related actions with package manager apt.