### PR TITLE
nginx: fix nginx installation and remove when-statement

### DIFF
--- a/nginx/tasks/installation.yml
+++ b/nginx/tasks/installation.yml
@@ -43,7 +43,6 @@
   tags:
     - 'role::nginx'
     - 'role::nginx:install'
-  when: item is defined and item
   notify:
     - 'nginx remove default vhost'
 


### PR DESCRIPTION
This when-statement prevents the task to install nginx.