### PR TITLE
network: sort interfaces in for loop

### DIFF
--- a/network/templates/etc/sysctl.d/network_ipv6_ra.conf.j2
+++ b/network/templates/etc/sysctl.d/network_ipv6_ra.conf.j2
@@ -3,7 +3,7 @@
 # Setting "all" and "default" does not help, you need to list
 # all interfaces here!
 
-{% for interface in ansible_interfaces %}
+{% for interface in ansible_interfaces | sort %}
 net.ipv6.conf.{{ interface }}.accept_ra=0
 net.ipv6.conf.{{ interface }}.autoconf=0
 


### PR DESCRIPTION
Sort the interfaces to prevent changing the same file with another order of the same devices.