### PR TITLE
use import_tasks instead of include

### DIFF
--- a/_template/tasks/main.yml
+++ b/_template/tasks/main.yml
@@ -10,12 +10,12 @@
     - 'role::$role:install'
     - 'role::$role:config'
 
-- include: installation.yml
+- import_tasks: installation.yml
   tags:
     - 'role::$role'
     - 'role::$role:install'
 
-- include: configuration.yml
+- import_tasks: configuration.yml
   tags:
     - 'role::$role'
     - 'role::$role:config'

--- a/ansible/tasks/main.yml
+++ b/ansible/tasks/main.yml
@@ -6,5 +6,5 @@
     - '{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml'
     - '{{ ansible_os_family }}.yml'
 
-- include: installation.yml
-- include: configuration.yml
+- import_tasks: installation.yml
+- import_tasks: configuration.yml

--- a/console/tasks/main.yml
+++ b/console/tasks/main.yml
@@ -10,5 +10,12 @@
     - 'role::console:install'
     - 'role::console:config'
 
-- include: installation.yml
-- include: configuration.yml
+- import_tasks: installation.yml
+  tags:
+    - 'role::console'
+    - 'role::console:install'
+
+- import_tasks: configuration.yml
+  tags:
+    - 'role::console'
+    - 'role::console:config'

--- a/grub/tasks/main.yml
+++ b/grub/tasks/main.yml
@@ -10,12 +10,12 @@
     - 'role::grub:install'
     - 'role::grub:config'
 
-- include: installation.yml
+- import_tasks: installation.yml
   tags:
     - 'role::grub'
     - 'role::grub:install'
 
-- include: configuration.yml
+- import_tasks: configuration.yml
   tags:
     - 'role::grub'
     - 'role::grub:config'

--- a/hostname/tasks/main.yml
+++ b/hostname/tasks/main.yml
@@ -10,5 +10,12 @@
     - 'role::hostname:install'
     - 'role::hostname:config'
 
-- include: installation.yml
-- include: configuration.yml
+- import_tasks: installation.yml
+  tags:
+    - 'role::hostname'
+    - 'role::hostname:install'
+
+- import_tasks: configuration.yml
+  tags:
+    - 'role::hostname'
+    - 'role::hostname:config'

--- a/hwraid/tasks/main.yml
+++ b/hwraid/tasks/main.yml
@@ -10,12 +10,12 @@
     - 'role::hwraid:install'
     - 'role::hwraid:config'
 
-- include: installation.yml
+- import_tasks: installation.yml
   tags:
     - 'role::hwraid'
     - 'role::hwraid:install'
 
-- include: configuration.yml
+- import_tasks: configuration.yml
   tags:
     - 'role::hwraid'
     - 'role::hwraid:config'

--- a/ipmi/tasks/main.yml
+++ b/ipmi/tasks/main.yml
@@ -19,13 +19,13 @@
     - 'role::ipmi:install'
     - 'role::ipmi:config'
 
-- include: installation.yml
+- import_tasks: installation.yml
   when: ipmi_register_device.stat.exists
   tags:
     - 'role::ipmi'
     - 'role::ipmi:install'
 
-- include: configuration.yml
+- import_tasks: configuration.yml
   when: ipmi_register_device.stat.exists
   tags:
     - 'role::ipmi'

--- a/iptables/tasks/main.yml
+++ b/iptables/tasks/main.yml
@@ -10,12 +10,12 @@
     - 'role::iptables:install'
     - 'role::iptables:config'
 
-- include: installation.yml
+- import_tasks: installation.yml
   tags:
     - 'role::iptables'
     - 'role::iptables:install'
 
-- include: configuration.yml
+- import_tasks: configuration.yml
   tags:
     - 'role::iptables'
     - 'role::iptables:config'

--- a/mariadb/tasks/main.yml
+++ b/mariadb/tasks/main.yml
@@ -10,12 +10,12 @@
     - 'role::mariadb:install'
     - 'role::mariadb:config'
 
-- include: installation.yml
+- import_tasks: installation.yml
   tags:
     - 'role::mariadb'
     - 'role::mariadb:install'
 
-- include: configuration.yml
+- import_tasks: configuration.yml
   tags:
     - 'role::mariadb'
     - 'role::mariadb:config'

--- a/motd/tasks/main.yml
+++ b/motd/tasks/main.yml
@@ -10,12 +10,12 @@
     - 'role::motd:install'
     - 'role::motd:config'
 
-- include: installation.yml
+- import_tasks: installation.yml
   tags:
     - 'role::motd'
     - 'role::motd:install'
 
-- include: configuration.yml
+- import_tasks: configuration.yml
   tags:
     - 'role::motd'
     - 'role::motd:config'

--- a/network/tasks/main.yml
+++ b/network/tasks/main.yml
@@ -10,5 +10,12 @@
     - 'role::network:install'
     - 'role::network:config'
 
-- include: installation.yml
-- include: configuration.yml
+- import_tasks: installation.yml
+  tags:
+    - 'role::network'
+    - 'role::network:install'
+
+- import_tasks: configuration.yml
+  tags:
+    - 'role::network'
+    - 'role::network:config'

--- a/nginx/tasks/main.yml
+++ b/nginx/tasks/main.yml
@@ -10,5 +10,12 @@
     - 'role::nginx:install'
     - 'role::nginx:config'
 
-- include: installation.yml
-- include: configuration.yml
+- import_tasks: installation.yml
+  tags:
+    - 'role::nginx'
+    - 'role::nginx:install'
+
+- import_tasks: configuration.yml
+  tags:
+    - 'role::nginx'
+    - 'role::nginx:config'

--- a/nodejs/tasks/main.yml
+++ b/nodejs/tasks/main.yml
@@ -5,6 +5,17 @@
   with_first_found:
     - '{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml'
     - '{{ ansible_os_family }}.yml'
+  tags:
+    - 'role::nodejs'
+    - 'role::nodejs:install'
+    - 'role::nodejs:config'
 
-- include: installation.yml
-- include: configuration.yml
+- import_tasks: installation.yml
+  tags:
+    - 'role::nodejs'
+    - 'role::nodejs:install'
+
+- import_tasks: configuration.yml
+  tags:
+    - 'role::nodejs'
+    - 'role::nodejs:config'

--- a/ntp/tasks/main.yml
+++ b/ntp/tasks/main.yml
@@ -10,12 +10,12 @@
     - 'role::ntp:install'
     - 'role::ntp:config'
 
-- include: installation.yml
+- import_tasks: installation.yml
   tags:
     - 'role::ntp'
     - 'role::ntp:install'
 
-- include: configuration.yml
+- import_tasks: configuration.yml
   tags:
     - 'role::ntp'
     - 'role::ntp:config'

--- a/pkg_mirror/tasks/main.yml
+++ b/pkg_mirror/tasks/main.yml
@@ -10,12 +10,12 @@
     - 'role::pkg_mirror:install'
     - 'role::pkg_mirror:config'
 
-- include: installation.yml
+- import_tasks: installation.yml
   tags:
     - 'role::pkg_mirror'
     - 'role::pkg_mirror:install'
 
-- include: configuration.yml
+- import_tasks: configuration.yml
   tags:
     - 'role::pkg_mirror'
     - 'role::pkg_mirror:config'

--- a/pki/tasks/main.yml
+++ b/pki/tasks/main.yml
@@ -10,12 +10,12 @@
     - 'role::pki:install'
     - 'role::pki:config'
 
-- include: installation.yml
+- import_tasks: installation.yml
   tags:
     - 'role::pki'
     - 'role::pki:install'
 
-- include: configuration.yml
+- import_tasks: configuration.yml
   tags:
     - 'role::pki'
     - 'role::pki:config'

--- a/postfix/tasks/main.yml
+++ b/postfix/tasks/main.yml
@@ -10,5 +10,12 @@
     - 'role::postfix:install'
     - 'role::postfix:config'
 
-- include: installation.yml
-- include: configuration.yml
+- import_tasks: installation.yml
+  tags:
+    - 'role::postfix'
+    - 'role::postfix:install'
+
+- import_tasks: configuration.yml
+  tags:
+    - 'role::postfix'
+    - 'role::postfix:config'

--- a/rpcbind/tasks/main.yml
+++ b/rpcbind/tasks/main.yml
@@ -10,5 +10,12 @@
     - 'role::rpcbind:install'
     - 'role::rpcbind:config'
 
-- include: installation.yml
-- include: configuration.yml
+- import_tasks: installation.yml
+  tags:
+    - 'role::rpcbind'
+    - 'role::rpcbind:install'
+
+- import_tasks: configuration.yml
+  tags:
+    - 'role::rpcbind'
+    - 'role::rpcbind:config'

--- a/rsyslog/tasks/main.yml
+++ b/rsyslog/tasks/main.yml
@@ -10,5 +10,12 @@
     - 'role::rsyslog:install'
     - 'role::rsyslog:config'
 
-- include: installation.yml
-- include: configuration.yml
+- import_tasks: installation.yml
+  tags:
+    - 'role::rsyslog'
+    - 'role::rsyslog:install'
+
+- import_tasks: configuration.yml
+  tags:
+    - 'role::rsyslog'
+    - 'role::rsyslog:config'

--- a/snmp/tasks/main.yml
+++ b/snmp/tasks/main.yml
@@ -10,5 +10,12 @@
     - 'role::snmp:install'
     - 'role::snmp:config'
 
-- include: installation.yml
-- include: configuration.yml
+- import_tasks: installation.yml
+  tags:
+    - 'role::snmp'
+    - 'role::snmp:install'
+
+- import_tasks: configuration.yml
+  tags:
+    - 'role::snmp'
+    - 'role::snmp:config'

--- a/ssh/tasks/main.yml
+++ b/ssh/tasks/main.yml
@@ -10,5 +10,12 @@
     - 'role::ssh:install'
     - 'role::ssh:config'
 
-- include: installation.yml
-- include: configuration.yml
+- import_tasks: installation.yml
+  tags:
+    - 'role::ssh'
+    - 'role::ssh:install'
+
+- import_tasks: configuration.yml
+  tags:
+    - 'role::ssh'
+    - 'role::ssh:config'

--- a/telegraf/tasks/main.yml
+++ b/telegraf/tasks/main.yml
@@ -10,5 +10,12 @@
     - 'role::telegraf:install'
     - 'role::telegraf:config'
 
-- include: installation.yml
-- include: configuration.yml
+- import_tasks: installation.yml
+  tags:
+    - 'role::telegraf'
+    - 'role::telegraf:install'
+
+- import_tasks: configuration.yml
+  tags:
+    - 'role::telegraf'
+    - 'role::telegraf:config'

--- a/upgrade/tasks/main.yml
+++ b/upgrade/tasks/main.yml
@@ -10,5 +10,12 @@
     - 'role::upgrade:install'
     - 'role::upgrade:config'
 
-- include: installation.yml
-- include: configuration.yml
+- import_tasks: installation.yml
+  tags:
+    - 'role::upgrade'
+    - 'role::upgrade:install'
+
+- import_tasks: configuration.yml
+  tags:
+    - 'role::upgrade'
+    - 'role::upgrade:config'

--- a/users/tasks/main.yml
+++ b/users/tasks/main.yml
@@ -10,5 +10,12 @@
     - 'role::users:install'
     - 'role::users:config'
 
-- include: installation.yml
-- include: configuration.yml
+- import_tasks: installation.yml
+  tags:
+    - 'role::users'
+    - 'role::users:install'
+
+- import_tasks: configuration.yml
+  tags:
+    - 'role::users'
+    - 'role::users:config'


### PR DESCRIPTION
The use of `include` for tasks has been deprecated. Use `import_tasks` for static inclusions or `include_tasks` for dynamic inclusions. This feature will be removed in a future release.