### PR TITLE
mariadb: generate ssl certificates for mariadb server

### DIFF
--- a/mariadb/defaults/main.yml
+++ b/mariadb/defaults/main.yml
@@ -68,6 +68,7 @@ mariadb_users: []
 # .. code-block:: YAML
 #
 #   mariadb_replicate_wild_do_table: ykksm.%
+#
 
 # Mariadb innodb_file_per_table
 #
@@ -84,3 +85,7 @@ mariadb_users: []
 # .. code-block:: YAML
 #
 #   mariadb_innodb_file_per_table: true
+#
+
+# Passphrase for SSL CA private key.
+mariadb_ca_privatekey_passphrase: ''

--- a/mariadb/defaults/main.yml
+++ b/mariadb/defaults/main.yml
@@ -89,3 +89,6 @@ mariadb_users: []
 
 # Passphrase for SSL CA private key.
 mariadb_ca_privatekey_passphrase: ''
+
+# Enable mariadb SSL encryption.
+mariadb_ssl: False

--- a/mariadb/meta/main.yml
+++ b/mariadb/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   description: 'Install and manage mariadb/mysql server'
   company: 'Adfinis SyGroup AG'
   license: 'GNU General Public License v3'
-  min_ansible_version: '2.1.0'
+  min_ansible_version: '2.3.0'
   platforms:
     - name: Debian
       versions:

--- a/mariadb/meta/main.yml
+++ b/mariadb/meta/main.yml
@@ -4,7 +4,7 @@ dependencies: []
 
 galaxy_info:
   author: 'Adfinis SyGroup AG'
-  description: 'Install and manage mariadb/mysql server'
+  description: 'Install and manage mariadb/mysql server. pyOpenSSL is locally also required.'
   company: 'Adfinis SyGroup AG'
   license: 'GNU General Public License v3'
   min_ansible_version: '2.3.0'

--- a/mariadb/tasks/configuration.yml
+++ b/mariadb/tasks/configuration.yml
@@ -14,6 +14,18 @@
   notify:
     - 'mariadb check config and restart'
 
+- name: create mariadb configuration directory
+  file:
+    path: '{{ mariadb_conf_dir }}'
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+    seuser: system_u
+    serole: object_r
+    setype: mysqld_etc_t
+    selevel: s0
+
 - name: enable mariadb service
   service:
     name: '{{ mariadb_service }}'

--- a/mariadb/tasks/main.yml
+++ b/mariadb/tasks/main.yml
@@ -9,6 +9,7 @@
     - 'role::mariadb'
     - 'role::mariadb:install'
     - 'role::mariadb:config'
+    - 'role::mariadb:ssl'
 
 - import_tasks: installation.yml
   tags:
@@ -19,3 +20,8 @@
   tags:
     - 'role::mariadb'
     - 'role::mariadb:config'
+
+- import_tasks: ssl.yml
+  tags:
+    - 'role::mariadb'
+    - 'role::mariadb:ssl'

--- a/mariadb/tasks/main.yml
+++ b/mariadb/tasks/main.yml
@@ -25,3 +25,4 @@
   tags:
     - 'role::mariadb'
     - 'role::mariadb:ssl'
+  when: mariadb_ssl

--- a/mariadb/tasks/ssl.yml
+++ b/mariadb/tasks/ssl.yml
@@ -71,6 +71,8 @@
     provider: selfsigned
   delegate_to: localhost
   register: mariadb_register_pem
+  tags:
+    - skip_ansible_lint
   when: mariadb_register_csr.changed
 
 - name: put the mariadb ssl certificate to the server
@@ -84,6 +86,8 @@
     serole: object_r
     setype: cert_t
     selevel: s0
+  tags:
+    - skip_ansible_lint
   when: mariadb_register_pem.changed
 
 - name: configure mysqld to use ssl

--- a/mariadb/tasks/ssl.yml
+++ b/mariadb/tasks/ssl.yml
@@ -1,0 +1,101 @@
+---
+
+- name: create mariadb pki path
+  file:
+    state: directory
+    path: '{{ mariadb_pki_path }}'
+    owner: '{{ mariadb_user }}'
+    group: '{{ mariadb_user }}'
+    mode: 0600
+    seuser: system_u
+    serole: object_r
+    setype: cert_t
+    selevel: s0
+
+- name: create mariadb ssl ca private key
+  openssl_privatekey:
+    path: tmp/mariadb_ssl_ca.key
+    type: RSA
+    cipher: aes256
+    size: 4096
+    passphrase: '{{ mariadb_ca_privatekey_passphrase }}'
+  delegate_to: localhost
+
+- name: create mariadb ssl ca public key
+  openssl_publickey:
+    path: tmp/mariadb_ssl_ca.pem
+    format: PEM
+    privatekey_path: tmp/mariadb_ssl_ca.key
+    privatekey_passphrase: '{{ mariadb_ca_privatekey_passphrase }}'
+  delegate_to: localhost
+
+- name: put the mariadb ssl ca public key to the server
+  copy:
+    src: tmp/mariadb_ssl_ca.pem
+    dest: '{{ mariadb_pki_path }}/ca.pem'
+    owner: root
+    group: root
+    mode: 0644
+    seuser: system_u
+    serole: object_r
+    setype: cert_t
+    selevel: s0
+
+- name: create mariadb ssl private key
+  openssl_privatekey:
+    path: '{{ mariadb_pki_path }}/server.key'
+    type: RSA
+    cipher: aes256
+    size: 4096
+    passphrase: ''
+
+- name: create mariadb ssl certificate signing request
+  openssl_csr:
+    path: '{{ mariadb_pki_path }}/server.csr'
+    common_name: '{{ ansible_fqdn }}'
+    privatekey_path: '{{ mariadb_pki_path }}/server.key'
+    privatekey_passphrase: ''
+
+- name: fetch mariadb ssl certificate signing request
+  fetch:
+    src: '{{ mariadb_pki_path }}/server.csr'
+    dest: 'tmp/mariadb_{{ ansible_fqdn }}.csr'
+    flat: yes
+  register: mariadb_register_csr
+
+- name: sign mariadb ssl certificate signing request
+  openssl_certificate:
+    path: 'tmp/mariadb_{{ ansible_fqdn }}.pem'
+    privatekey_path: 'tmp/mariadb_ssl_ca.key'
+    csr_path: 'tmp/mariadb_{{ ansible_fqdn }}.csr'
+    provider: selfsigned
+  delegate_to: localhost
+  register: mariadb_register_pem
+  when: mariadb_register_csr.changed
+
+- name: put the mariadb ssl certificate to the server
+  copy:
+    src: 'tmp/mariadb_{{ ansible_fqdn }}.pem'
+    dest: '{{ mariadb_pki_path }}/server.pem'
+    owner: root
+    group: root
+    mode: 0644
+    seuser: system_u
+    serole: object_r
+    setype: cert_t
+    selevel: s0
+  when: mariadb_register_pem.changed
+
+- name: configure mysqld to use ssl
+  template:
+    src: etc/mariadb/ssl.conf.j2
+    dest: '{{ mariadb_conf_dir }}/ssl.conf'
+    owner: root
+    group: root
+    mode: 0644
+    seuser: system_u
+    serole: object_r
+    setype: mariadb_etc_t
+    selevel: s0
+  notify:
+    - 'mariadb check config and restart'

--- a/mariadb/templates/etc/mariadb/ssl.conf.j2
+++ b/mariadb/templates/etc/mariadb/ssl.conf.j2
@@ -1,0 +1,11 @@
+# {{ ansible_managed }}
+#
+# The MySQL database server configuration file.
+#
+# * Security Features
+#
+
+[mysqld]
+ssl-ca                  = {{ mariadb_pki_path }}/ca.pem
+ssl-cert                = {{ mariadb_pki_path }}/server.pem
+ssl-key                 = {{ mariadb_pki_path }}/server.key

--- a/mariadb/templates/etc/my.cnf.j2
+++ b/mariadb/templates/etc/my.cnf.j2
@@ -142,4 +142,4 @@ key_buffer              = 16M
 # * IMPORTANT: Additional settings that can override those from this file!
 #   The files must end with '.cnf', otherwise they'll be ignored.
 #
-#!includedir /etc/mysql/conf.d/
+!includedir {{ mariadb_conf_dir }}/

--- a/mariadb/vars/CentOS_6.yml
+++ b/mariadb/vars/CentOS_6.yml
@@ -6,15 +6,22 @@ mariadb_packages:
   - mysql-server
   - MySQL-python
   - pwgen
+  - pyOpenSSL
 
 # mariadb service name
 mariadb_service: mysqld
+
+# mariadb user
+mariadb_user: mysql
 
 # mariadb server binary
 mariadb_server_bin: /usr/libexec/mysqld
 
 # global mariadb configuration file location
 mariadb_conf: /etc/my.cnf
+
+# global mariadb configuration directory
+mariadb_conf_dir: /etc/mysql/conf.d
 
 # roots my.cnf
 mariadb_root_mycnf: /root/.my.cnf
@@ -35,3 +42,6 @@ mariadb_socket: '{{ mariadb_run_dir }}/mysqld.sock'
 mariadb_anon_user_hosts:
   - localhost
   - '{{ ansible_fqdn }}'
+
+# mariadb pki path
+mariadb_pki_path: /etc/pki/mariadb

--- a/mariadb/vars/Debian.yml
+++ b/mariadb/vars/Debian.yml
@@ -6,15 +6,22 @@ mariadb_packages:
   - mariadb-client
   - python-mysqldb
   - pwgen
+  - python-openssl
 
 # mariadb service name
 mariadb_service: mysql
+
+# mariadb user
+mariadb_user: mysql
 
 # mariadb server binary
 mariadb_server_bin: /usr/sbin/mysqld
 
 # global mariadb configuration file location
 mariadb_conf: /etc/mysql/my.cnf
+
+# global mariadb configuration directory
+mariadb_conf_dir: /etc/mysql/conf.d
 
 # roots my.cnf
 mariadb_root_mycnf: /root/.my.cnf
@@ -33,3 +40,6 @@ mariadb_socket: '{{ mariadb_run_dir }}/mysqld.sock'
 
 # mariadb anonymous users
 mariadb_anon_user_hosts: []
+
+# mariadb pki path
+mariadb_pki_path: /etc/mysql

--- a/mariadb/vars/Debian_7.yml
+++ b/mariadb/vars/Debian_7.yml
@@ -6,15 +6,22 @@ mariadb_packages:
   - mysql-client
   - python-mysqldb
   - pwgen
+  - python-openssl
 
 # mariadb service name
 mariadb_service: mysql
+
+# mariadb user
+mariadb_user: mysql
 
 # mariadb server binary
 mariadb_server_bin: /usr/sbin/mysqld
 
 # global mariadb configuration file location
 mariadb_conf: /etc/my.cnf
+
+# global mariadb configuration directory
+mariadb_conf_dir: /etc/mysql/conf.d
 
 # roots my.cnf
 mariadb_root_mycnf: /root/.my.cnf
@@ -33,3 +40,6 @@ mariadb_socket: '{{ mariadb_run_dir }}/mysqld.sock'
 
 # mariadb anonymous users
 mariadb_anon_user_hosts: []
+
+# mariadb pki path
+mariadb_pki_path: /etc/mysql

--- a/mariadb/vars/RedHat.yml
+++ b/mariadb/vars/RedHat.yml
@@ -6,15 +6,22 @@ mariadb_packages:
   - mariadb-server
   - MySQL-python
   - pwgen
+  - pyOpenSSL
 
 # mariadb service name
 mariadb_service: mariadb
+
+# mariadb user
+mariadb_user: mysql
 
 # mariadb server binary
 mariadb_server_bin: /usr/libexec/mysqld
 
 # global mariadb configuration file location
 mariadb_conf: /etc/my.cnf
+
+# global mariadb configuration directory
+mariadb_conf_dir: /etc/mysql/conf.d
 
 # roots my.cnf
 mariadb_root_mycnf: /root/.my.cnf
@@ -35,3 +42,6 @@ mariadb_socket: '{{ mariadb_run_dir }}/mysqld.sock'
 mariadb_anon_user_hosts:
   - localhost
   - '{{ ansible_fqdn }}'
+
+# mariadb pki path
+mariadb_pki_path: /etc/pki/mariadb


### PR DESCRIPTION
Add SSL support to mariadb/mysql server. Auto generate SSL certificates.