### PR TITLE
ipmi: load kernel modules before checking if device is present

### DIFF
--- a/ipmi/tasks/kernelmod.yml
+++ b/ipmi/tasks/kernelmod.yml
@@ -1,0 +1,12 @@
+---
+
+- name: load ipmi kernel modules
+  modprobe:
+    name: '{{ item }}'
+    state: present
+  with_items: '{{ ipmi_kernel_modules }}'
+
+- name: check if an ipmi module is present
+  stat:
+    path: '{{ ipmi_device_path }}'
+  register: ipmi_register_device

--- a/ipmi/tasks/main.yml
+++ b/ipmi/tasks/main.yml
@@ -10,23 +10,20 @@
     - 'role::ipmi:install'
     - 'role::ipmi:config'
 
-- name: check if an ipmi module is present
-  stat:
-    path: '{{ ipmi_device_path }}'
-  register: ipmi_register_device
+- import_tasks: kernelmod.yml
   tags:
     - 'role::ipmi'
     - 'role::ipmi:install'
     - 'role::ipmi:config'
 
 - import_tasks: installation.yml
-  when: ipmi_register_device.stat.exists
+  when: ipmi_register_device.stat.exists | default(False)
   tags:
     - 'role::ipmi'
     - 'role::ipmi:install'
 
 - import_tasks: configuration.yml
-  when: ipmi_register_device.stat.exists
+  when: ipmi_register_device.stat.exists | default(False)
   tags:
     - 'role::ipmi'
     - 'role::ipmi:config'

--- a/ipmi/vars/Debian.yml
+++ b/ipmi/vars/Debian.yml
@@ -4,6 +4,12 @@
 ipmi_packages:
   - ipmitool
 
+# IPMI kernel modules
+ipmi_kernel_modules:
+  - ipmi_si
+  - ipmi_msghandler
+  - ipmi_devintf
+
 # Path to the kernel modules load path for the ipmi tools
 ipmi_kernel_modules_conf: /etc/modules-load.d/ipmi.conf
 

--- a/ipmi/vars/RedHat.yml
+++ b/ipmi/vars/RedHat.yml
@@ -4,6 +4,12 @@
 ipmi_packages:
   - ipmitool
 
+# IPMI kernel modules
+ipmi_kernel_modules:
+  - ipmi_si
+  - ipmi_msghandler
+  - ipmi_devintf
+
 # Path to the kernel modules load path for the ipmi tools
 ipmi_kernel_modules_conf: /etc/modules-load.d/ipmi.conf
 


### PR DESCRIPTION
If the kernel module `ipmi_devintf` isn't loaded, there is no `/dev/ipmi?` file.