### PR TITLE
pkg mirror: update apt cache isn't a real change

### DIFF
--- a/pkg_mirror/tasks/installation.yml
+++ b/pkg_mirror/tasks/installation.yml
@@ -3,6 +3,7 @@
 - name: update apt cache
   apt:
     update_cache: yes
+  changed_when: False
   when: ansible_os_family == 'Debian'
 
 - name: install pkg_mirror packages


### PR DESCRIPTION
Updating the apt cache is everytime changed, so deactivate the changed flag. Updating the cache doesn't really affect the system, so disabling the changed flag is IMHO passable.