### PR TITLE
ipmi: load only kernel module to detect ipmi devices

### DIFF
--- a/ipmi/tasks/kernelmod.yml
+++ b/ipmi/tasks/kernelmod.yml
@@ -4,7 +4,7 @@
   modprobe:
     name: '{{ item }}'
     state: present
-  with_items: '{{ ipmi_kernel_modules }}'
+  with_items: '{{ ipmi_kernel_modules_device }}'
 
 - name: check if an ipmi module is present
   stat:

--- a/ipmi/vars/Debian.yml
+++ b/ipmi/vars/Debian.yml
@@ -4,10 +4,8 @@
 ipmi_packages:
   - ipmitool
 
-# IPMI kernel modules
-ipmi_kernel_modules:
-  - ipmi_si
-  - ipmi_msghandler
+# IPMI kernel module for device
+ipmi_kernel_modules_device:
   - ipmi_devintf
 
 # Path to the kernel modules load path for the ipmi tools

--- a/ipmi/vars/RedHat.yml
+++ b/ipmi/vars/RedHat.yml
@@ -4,10 +4,8 @@
 ipmi_packages:
   - ipmitool
 
-# IPMI kernel modules
-ipmi_kernel_modules:
-  - ipmi_si
-  - ipmi_msghandler
+# IPMI kernel module for device
+ipmi_kernel_modules_device:
   - ipmi_devintf
 
 # Path to the kernel modules load path for the ipmi tools


### PR DESCRIPTION
On installation, only load the kernel module to detect if a IPMI device is present. The other kernel modules can be loaded while configuration.
The kernel module `ipmi_si` can't be loaded if no IPMI device is present, so this PR will fix a bug.