### PR TITLE
Network human error prevention

### DIFF
--- a/network/tasks/configuration.yml
+++ b/network/tasks/configuration.yml
@@ -11,9 +11,6 @@
     serole: object_r
     setype: etc_t
     selevel: s0
-  tags:
-    - 'role::network'
-    - 'role::network:config'
   notify:
     - 'network reload sysctl'
 
@@ -28,9 +25,6 @@
     serole: object_r
     setype: etc_t
     selevel: s0
-  tags:
-    - 'role::network'
-    - 'role::network:config'
   notify:
     - 'network reload sysctl'
 
@@ -45,9 +39,6 @@
     serole: object_r
     setype: etc_t
     selevel: s0
-  tags:
-    - 'role::network'
-    - 'role::network:config'
 
 - name: create network interface configuration directory
   file:
@@ -72,9 +63,6 @@
     serole: object_r
     setype: net_conf_t
     selevel: s0
-  tags:
-    - 'role::network'
-    - 'role::network:config'
   when: item.device is defined and item.device and
         item.tmpl is defined and item.tmpl and
         (item.device in ansible_interfaces or
@@ -92,6 +80,3 @@
     serole: object_r
     setype: net_conf_t
     selevel: s0
-  tags:
-    - 'role::network'
-    - 'role::network:config'

--- a/network/tasks/configuration.yml
+++ b/network/tasks/configuration.yml
@@ -39,6 +39,7 @@
     serole: object_r
     setype: etc_t
     selevel: s0
+  when: network_interfaces is defined and network_interfaces
 
 - name: create network interface configuration directory
   file:

--- a/network/tasks/installation.yml
+++ b/network/tasks/installation.yml
@@ -4,14 +4,8 @@
   package:
     name: '{{ network_packages }}'
     state: present
-  tags:
-    - 'role::network'
-    - 'role::network:install'
 
 - name: remove non rfc 1149 compatible software
   package:
     name: '{{ network_packages_removed }}'
     state: absent
-  tags:
-    - 'role::network'
-    - 'role::network:install'


### PR DESCRIPTION
Don't overwrite the main network configuration, when no interface is specified. This will prevent the network role to overwrite the actual network configuration, when no configuration is given.