### PR TITLE
Mariadb fixes

### DIFF
--- a/mariadb/tasks/installation.yml
+++ b/mariadb/tasks/installation.yml
@@ -12,10 +12,10 @@
 - name: create mariadb configuration directory
   file:
     path: '{{ mariadb_conf_dir }}'
-    recurse: yes
     owner: root
     group: root
     mode: 0755
+    state: directory
     seuser: system_u
     serole: object_r
     setype: mysqld_etc_t

--- a/mariadb/vars/Ubuntu_14.yml
+++ b/mariadb/vars/Ubuntu_14.yml
@@ -9,7 +9,7 @@ mariadb_packages:
   - python-openssl
 
 # mariadb service name
-mariadb_service: mysqld
+mariadb_service: mysql
 
 # mariadb user
 mariadb_user: mysql

--- a/mariadb/vars/Ubuntu_16.yml
+++ b/mariadb/vars/Ubuntu_16.yml
@@ -9,7 +9,7 @@ mariadb_packages:
   - python-openssl
 
 # mariadb service name
-mariadb_service: mysqld
+mariadb_service: mysql
 
 # mariadb user
 mariadb_user: mysql


### PR DESCRIPTION
- Ubuntu has a service called `mysql` and not `mysqld`.
- The main configuration directory was created with `state=file`, but should be created with `state=directory`.
- The main configuration directory shouldn't be created with `recursive=yes`, this changes the modes of files under this path.