### PR TITLE
grub: add optional additional cmdline parameters

### DIFF
--- a/grub/defaults/main.yml
+++ b/grub/defaults/main.yml
@@ -18,3 +18,7 @@ grub_timeout: 5
 
 # disable predictable network interface names
 grub_disable_network_predictable_interface_names: True
+
+# additional cmdline arguments
+# type: list
+grub_cmdline_linux_list: []

--- a/grub/defaults/main.yml
+++ b/grub/defaults/main.yml
@@ -22,3 +22,12 @@ grub_disable_network_predictable_interface_names: True
 # additional cmdline arguments
 # type: list
 grub_cmdline_linux_list: []
+
+# An example how to add additional parameters to the kernel:
+#
+# .. code-block:: YAML
+#
+#   grub_cmdline_linux_list:
+#     - ip=192.0.2.2::192.0.2.1:255.255.255.0:host.example.com:eth0:off
+#     - vnc
+#     - vncpassword=password

--- a/grub/templates/etc/default/grub.j2
+++ b/grub/templates/etc/default/grub.j2
@@ -1,7 +1,7 @@
 {% if grub_consoles | d(False) %}
 {%   set grub_console = "console=" + grub_consoles | join(' console=') %}
 {% endif %}
-{% set grub_cmdline_linux = [] %}
+{% set grub_cmdline_linux = [] + grub_cmdline_linux_list %}
 {% if ansible_cmdline['rd.auto'] | d(False) %}
 {%   set grub_cmdline_linux = grub_cmdline_linux + ['rd.auto'] %}
 {% endif %}


### PR DESCRIPTION
Sometimes additional cmdline options are needed. This PR allows to add a free list of additional cmdline options.