### PR TITLE
network: don't set sysctl rules for vnet* devices, they change to often

### DIFF
--- a/network/templates/etc/sysctl.d/network_ipv6_ra.conf.j2
+++ b/network/templates/etc/sysctl.d/network_ipv6_ra.conf.j2
@@ -1,9 +1,12 @@
+{% set interfaces_all       = ansible_interfaces | sort %}
+{% set interfaces_unwanted  = interfaces_all | map('regex_search', '^vnet[0-9]+') | list | difference([None]) %}
+{% set interfaces           = interfaces_all | difference(interfaces_unwanted) %}
 # {{ ansible_managed }}
 # Do not accept IPv6 default routes on external interfaces
 # Setting "all" and "default" does not help, you need to list
 # all interfaces here!
 
-{% for interface in ansible_interfaces | sort %}
+{% for interface in interfaces %}
 net.ipv6.conf.{{ interface }}.accept_ra=0
 net.ipv6.conf.{{ interface }}.autoconf=0
 


### PR DESCRIPTION
Each kvm hypervisor has for each VM some `vnet*` devices. We are not interested in setting `net.ipv6.conf.vnet0.accept_ra=0` and `net.ipv6.conf.vnet0.autoconf=0` sysctl values, they would change to often.
This patch will exclude all `^vnet\d+` devices from sysctl configuration.