### PR TITLE
Rename CentOS platform to EL in metadata

### DIFF
--- a/_template/meta/main.yml
+++ b/_template/meta/main.yml
@@ -18,7 +18,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/ansible/meta/main.yml
+++ b/ansible/meta/main.yml
@@ -19,7 +19,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/console/meta/main.yml
+++ b/console/meta/main.yml
@@ -18,7 +18,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/docker/meta/main.yml
+++ b/docker/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 7
   galaxy_tags:

--- a/grub/meta/main.yml
+++ b/grub/meta/main.yml
@@ -18,7 +18,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 7
   galaxy_tags:

--- a/hostname/meta/main.yml
+++ b/hostname/meta/main.yml
@@ -19,7 +19,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/hw_vm_tools/meta/main.yml
+++ b/hw_vm_tools/meta/main.yml
@@ -18,7 +18,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/hwraid/meta/main.yml
+++ b/hwraid/meta/main.yml
@@ -18,7 +18,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/ipmi/meta/main.yml
+++ b/ipmi/meta/main.yml
@@ -18,7 +18,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/iptables/meta/main.yml
+++ b/iptables/meta/main.yml
@@ -18,7 +18,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/mariadb/meta/main.yml
+++ b/mariadb/meta/main.yml
@@ -18,7 +18,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/motd/meta/main.yml
+++ b/motd/meta/main.yml
@@ -18,7 +18,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/network/meta/main.yml
+++ b/network/meta/main.yml
@@ -18,7 +18,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/nginx/meta/main.yml
+++ b/nginx/meta/main.yml
@@ -19,7 +19,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/nodejs/meta/main.yml
+++ b/nodejs/meta/main.yml
@@ -17,7 +17,7 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 7
   galaxy_tags:

--- a/ntp/meta/main.yml
+++ b/ntp/meta/main.yml
@@ -19,7 +19,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/pkg_mirror/meta/main.yml
+++ b/pkg_mirror/meta/main.yml
@@ -18,7 +18,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/pki/meta/main.yml
+++ b/pki/meta/main.yml
@@ -19,7 +19,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/postfix/meta/main.yml
+++ b/postfix/meta/main.yml
@@ -18,7 +18,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/rpcbind/meta/main.yml
+++ b/rpcbind/meta/main.yml
@@ -18,7 +18,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/rsyslog/meta/main.yml
+++ b/rsyslog/meta/main.yml
@@ -19,7 +19,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/snmp/meta/main.yml
+++ b/snmp/meta/main.yml
@@ -18,7 +18,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/ssh/meta/main.yml
+++ b/ssh/meta/main.yml
@@ -18,7 +18,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/telegraf/meta/main.yml
+++ b/telegraf/meta/main.yml
@@ -19,7 +19,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/upgrade/meta/main.yml
+++ b/upgrade/meta/main.yml
@@ -18,7 +18,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7

--- a/users/meta/main.yml
+++ b/users/meta/main.yml
@@ -19,7 +19,7 @@ galaxy_info:
       versions:
         - trusty
         - xenial
-    - name: CentOS
+    - name: EL
       versions:
         - 6
         - 7


### PR DESCRIPTION
This fixes #50.

See https://galaxy.ansible.com/api/v1/platforms/ for a list of supported platforms.