### PR TITLE
console: enable modeline in vim

### DIFF
--- a/console/templates/etc/vimrc.j2
+++ b/console/templates/etc/vimrc.j2
@@ -72,3 +72,6 @@ let &guicursor = &guicursor . ",a:blinkon0"
 " Suffixes that get lower priority when doing tab completion for filenames.
 " These are files we are not likely to want to edit or read.
 set suffixes=.bak,~,.swp,.o,.info,.aux,.log,.dvi,.bbl,.blg,.brf,.cb,.ind,.idx,.ilg,.inx,.out,.toc
+
+" Enable modelines if there are some in files.
+set modeline


### PR DESCRIPTION
If a file has a modeline, we should read that. This helps to have cleaner files (like not mixed tabs and spaces).